### PR TITLE
Fix gallery popper height

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -341,7 +341,7 @@ p.bold {
   color: #303133 !important;
   font-size: 12px;
   line-height: 1rem;
-  height: 1rem;
+  height: fit-content;
   padding: 10px;
 }
 .gallery-popper.el-popper[x-placement^='top'] .popper__arrow {


### PR DESCRIPTION
This fix is for the following PR review.
Instead of using fixed height, `4rem`, I use `fit-content` to follow the height of the popper's inner content to work with dynamic content.
https://github.com/nih-sparc/sparc-app-2/pull/158